### PR TITLE
Merge feat/mdc-instance-access into master

### DIFF
--- a/__tests__/button.spec.jsx
+++ b/__tests__/button.spec.jsx
@@ -21,14 +21,20 @@
  * SOFTWARE.
  */
 
-/* global describe, it, expect */
+/* global describe, afterEach, it, expect */
 import 'regenerator-runtime/runtime';
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
+import { MDCRipple } from '@material/ripple';
+import { render, cleanup } from '@testing-library/react';
 import { htmlOfRendering } from './utils';
 
 import Button from '../lib/button';
 
 describe('Button component', () => {
+  afterEach(async () => {
+    await cleanup();
+  });
+
   it('supports text buttons', () => {
     expect(htmlOfRendering(
       <Button label="foo"/>,
@@ -49,29 +55,42 @@ describe('Button component', () => {
 
   it('supports outlined buttons', () => {
     expect(htmlOfRendering(
-      <Button variation='outlined' label="foo"/>,
+      <Button variation="outlined" label="foo"/>,
     )).resolves.toMatchSnapshot();
 
     expect(htmlOfRendering(
-      <Button type="button" variation='outlined' label="foo" icon="favorite" supportsTouch={true}/>,
+      <Button type="button" variation="outlined" label="foo" icon="favorite" supportsTouch={true}/>,
     )).resolves.toMatchSnapshot();
 
     expect(htmlOfRendering(
-      <Button variation='outlined' label="foo" className="bar" iconClassName="fa fa-aws" disabled={true}/>,
+      <Button variation="outlined" label="foo" className="bar" iconClassName="fa fa-aws" disabled={true}/>,
     )).resolves.toMatchSnapshot();
   });
 
   it('supports contained buttons', () => {
     expect(htmlOfRendering(
-      <Button variation='contained' label="foo"/>,
+      <Button variation="contained" label="foo"/>,
     )).resolves.toMatchSnapshot();
 
     expect(htmlOfRendering(
-      <Button type="button" variation='contained' label="foo" icon="favorite" supportsTouch={true}/>,
+      <Button type="button" variation="contained" label="foo" icon="favorite" supportsTouch={true}/>,
     )).resolves.toMatchSnapshot();
 
     expect(htmlOfRendering(
-      <Button variation='contained' label="foo" className="bar" iconClassName="fa fa-aws" disabled={true}/>,
+      <Button variation="contained" label="foo" className="bar" iconClassName="fa fa-aws" disabled={true}/>,
     )).resolves.toMatchSnapshot();
+  });
+
+  it('can provide an MDCRipple instance', async () => {
+    let mdcRippleComponent;
+    function MyButton() {
+      const mdcRippleRef = useRef();
+      useEffect(() => {
+        mdcRippleComponent = mdcRippleRef.current;
+      });
+      return <Button label="foo" mdcRippleRef={mdcRippleRef}/>;
+    }
+    render(<MyButton/>);
+    expect(mdcRippleComponent).toBeInstanceOf(MDCRipple);
   });
 });

--- a/__tests__/data-table.spec.jsx
+++ b/__tests__/data-table.spec.jsx
@@ -23,7 +23,8 @@
 
 /* global jest, beforeAll, afterEach, describe, it, expect */
 import 'regenerator-runtime/runtime';
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
+import { MDCDataTable } from '@material/data-table';
 import { render, cleanup } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { htmlOfRendering } from './utils';
@@ -187,6 +188,40 @@ describe('DataTable component', () => {
     expect(htmlOfRendering(
       <DataTable data={dataSource} keyField="id" columns={columns}/>,
     )).resolves.toMatchSnapshot();
+  });
+
+  it('can provide an MDCDataTable instance', async () => {
+    let mdcComponent;
+    function MyDataTable() {
+      const columns = [{
+        key: 'id',
+        header: 'ID',
+        content: 'id',
+        isNumeric: true,
+        isRowHeader: true,
+        className: 'id-cell',
+        isSortable: true,
+        sortStatus: 'ascending',
+      }, {
+        key: 'composer-name',
+        header: 'Composer Name',
+        content: 'composer.name',
+        className: 'composer-cell',
+        bodyClassName: 'composer-body-cell',
+        isSortable: true,
+      }, {
+        key: 'detail-link',
+        content: (music) => <a href={`./${music.id}`}>Show Details</a>, // eslint-disable-line react/display-name
+        headerClassName: 'none',
+      }];
+      const mdcDataTableRef = useRef();
+      useEffect(() => {
+        mdcComponent = mdcDataTableRef.current;
+      });
+      return <DataTable data={dataSource} keyField="id" columns={columns} mdcDataTableRef={mdcDataTableRef}/>;
+    }
+    render(<MyDataTable/>);
+    expect(mdcComponent).toBeInstanceOf(MDCDataTable);
   });
 
   it('fires onRowSelectionChanged, onSelectedAll and onUnselectedAll evnet when a checkbox is clicked', async () => {

--- a/__tests__/icon-button.spec.jsx
+++ b/__tests__/icon-button.spec.jsx
@@ -21,14 +21,20 @@
  * SOFTWARE.
  */
 
-/* global describe, it, expect */
+/* global describe afterEach, it, expect, */
 import 'regenerator-runtime/runtime';
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
+import { MDCRipple } from '@material/ripple';
+import { render, cleanup } from '@testing-library/react';
 import { htmlOfRendering } from './utils';
 
 import IconButton from '../lib/icon-button';
 
 describe('IconButton component', () => {
+  afterEach(async () => {
+    await cleanup();
+  });
+
   it('supports material icon buttons', () => {
     expect(htmlOfRendering(
       <IconButton className="material-icons" icon="favorite"/>,
@@ -53,5 +59,18 @@ describe('IconButton component', () => {
         </svg>
       </IconButton>,
     )).resolves.toMatchSnapshot();
+  });
+
+  it('can provide an MDCRipple instance', async () => {
+    let mdcRippleComponent;
+    function MyIconButton() {
+      const mdcRippleRef = useRef();
+      useEffect(() => {
+        mdcRippleComponent = mdcRippleRef.current;
+      });
+      return <IconButton className="material-icons" icon="favorite" mdcRippleRef={mdcRippleRef}/>;
+    }
+    render(<MyIconButton/>);
+    expect(mdcRippleComponent).toBeInstanceOf(MDCRipple);
   });
 });

--- a/__tests__/icon-toggle.spec.jsx
+++ b/__tests__/icon-toggle.spec.jsx
@@ -21,14 +21,21 @@
  * SOFTWARE.
  */
 
-/* global describe, it, expect */
+/* global describe, afterEach, it, expect */
 import 'regenerator-runtime/runtime';
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
+import { MDCIconButtonToggle } from '@material/icon-button';
+import { MDCRipple } from '@material/ripple';
+import { render, cleanup } from '@testing-library/react';
 import { htmlOfRendering } from './utils';
 
 import IconToggle from '../lib/icon-toggle';
 
 describe('IconToggle component', () => {
+  afterEach(async () => {
+    await cleanup();
+  });
+
   it('supports material icon toggle buttons', () => {
     expect(htmlOfRendering(
       <IconToggle iconClassName="material-icons" onIcon="visibility" offIcon="visibility_off" label="visibility"/>,
@@ -66,5 +73,25 @@ describe('IconToggle component', () => {
         </IconToggle.OnSVG>
       </IconToggle>,
     )).resolves.toMatchSnapshot();
+  });
+
+  it('can provide an MDCIconButtonToggle instance', async () => {
+    let mdcIconButtonToggleComponent;
+    let mdcRippleComponent;
+    function MyIconButtonToggle() {
+      const mdcIconButtonToggleRef = useRef();
+      const mdcRippleRef = useRef();
+      useEffect(() => {
+        mdcIconButtonToggleComponent = mdcIconButtonToggleRef.current;
+        mdcRippleComponent = mdcRippleRef.current;
+      });
+      return <IconToggle iconClassName="material-icons"
+                         onIcon="visibility" offIcon="visibility_off"
+                         mdcIconButtonToggleRef={mdcIconButtonToggleRef}
+                         mdcRippleRef={mdcRippleRef}/>;
+    }
+    render(<MyIconButtonToggle/>);
+    expect(mdcIconButtonToggleComponent).toBeInstanceOf(MDCIconButtonToggle);
+    expect(mdcRippleComponent).toBeInstanceOf(MDCRipple);
   });
 });

--- a/__tests__/select.spec.jsx
+++ b/__tests__/select.spec.jsx
@@ -23,7 +23,8 @@
 
 /* global jest, describe, afterEach, it, expect */
 import 'regenerator-runtime/runtime';
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
+import { MDCSelect } from '@material/select';
 import { render, cleanup } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { htmlOfRendering, findByOpenedMenu, getByMenuItem } from './utils';
@@ -83,6 +84,19 @@ describe('Select component', () => {
       // Selected value is 'two', which has index: 1.
       <Select label="foo" items={items} value="1" itemsTextAttr="value" />,
     )).resolves.toMatchSnapshot();
+  });
+
+  it('can provide an MDCSelect instance', async () => {
+    let mdcSelectComponent;
+    function MySelect() {
+      const mdcSelectRef = useRef();
+      useEffect(() => {
+        mdcSelectComponent = mdcSelectRef.current;
+      });
+      return <Select label="foo" items={['one', 'two', 'three']} mdcSelectRef={mdcSelectRef}/>;
+    }
+    render(<MySelect/>);
+    expect(mdcSelectComponent).toBeInstanceOf(MDCSelect);
   });
 
   it('fires onChange event when the value is changed', async () => {

--- a/__tests__/tab.spec.jsx
+++ b/__tests__/tab.spec.jsx
@@ -23,7 +23,9 @@
 
 /* global jest, describe, afterEach, it, expect */
 import 'regenerator-runtime/runtime';
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
+import { MDCTabBar } from '@material/tab-bar';
+import { MDCTab } from '@material/tab';
 import { render, cleanup } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { htmlOfRendering } from './utils';
@@ -52,6 +54,35 @@ describe('Tab and TabBar component', () => {
         <Tab label="baz" className="tab" active={true}/>
       </TabBar>
     ))).resolves.toMatchSnapshot();
+  });
+
+  it('can provide an MDCTab and MDCTabBar instance', async () => {
+    let mdcTabBarComponent;
+    let mdcTabComponent1;
+    let mdcTabComponent2;
+    function MyTabs() {
+      const mdcTabBarRef = useRef();
+      const mdcTabRef1 = useRef();
+      const mdcTabRef2 = useRef();
+      useEffect(() => {
+        mdcTabBarComponent = mdcTabBarRef.current;
+        mdcTabComponent1 = mdcTabRef1.current;
+        mdcTabComponent2 = mdcTabRef2.current;
+      });
+      return (
+        <TabBar mdcTabBarRef={mdcTabBarRef}>
+          <Tab label="foo" active={true} mdcTabRef={mdcTabRef1}/>
+          <Tab label="bar" mdcTabRef={mdcTabRef2}/>
+          <Tab label="baz"/>
+        </TabBar>
+      );
+    }
+    render(<MyTabs/>);
+    expect(mdcTabBarComponent).toBeInstanceOf(MDCTabBar);
+    expect(mdcTabComponent1).toBeInstanceOf(MDCTab);
+    expect(mdcTabComponent2).toBeInstanceOf(MDCTab);
+    expect(mdcTabComponent1.active).toBe(true);
+    expect(mdcTabComponent2.active).toBe(false);
   });
 
   it('fires onActivated event when the tab is activated', () => {

--- a/lib/alert-dialog.jsx
+++ b/lib/alert-dialog.jsx
@@ -38,6 +38,8 @@ import Dialog from './dialog';
  * @param {string} props.buttons[].label The label of the action button.
  * @param {string} [props.buttons[].isDefault] Specifies `true` if the button means the
  * default action, otherwise `false`. Default to `false`.
+ * @param {React.MutableRefObject} [props.mdcDialogRef] MutableRefObject which bind an
+ * MDCDialog instance to.
  * @param {EventHandler} [props.onOpening] Specifies event handler that is called when
  * the dialog begins its opening animation.
  * @param {EventHandler} [props.onOpened] Specifies event handler that is called when

--- a/lib/button.jsx
+++ b/lib/button.jsx
@@ -26,7 +26,7 @@ import { MDCRipple } from '@material/ripple';
 
 const NON_NATIVE_PROPS = [
   'variation', 'label', 'className', 'icon', 'iconClassName', 'supportsTouch', 'ref',
-  'disablesMdcInstance',
+  'disablesMdcInstance', 'mdcRippleRef',
 ];
 
 const generateRootClassName = (props) => {
@@ -82,6 +82,8 @@ function IconElement(props) {
  * instantiate MDC Component. Default to `false`.
  * @param {boolean} [props.supportsTouch] Whether to support touch in Material Design
  * specification. Material Design spec advises that touch targets should be at least 48 x 48 px.
+ * @param {React.MutableRefObject} [props.mdcRippleRef] MutableRefObject which bind an
+ * MDCRipple instance to. The instance is not bind if `props.disablesMdcInstance` is `true`.
  * @returns {DetailedReactHTMLElement}
  * @exports material-react-js
  */
@@ -93,6 +95,9 @@ export default function Button(props) {
       return () => {};
     }
     const mdcComponent = new MDCRipple(rootElement.current);
+    if (props.mdcRippleRef) {
+      props.mdcRippleRef.current = mdcComponent; // eslint-disable-line no-param-reassign
+    }
     return () => {
       mdcComponent.destroy();
     };

--- a/lib/checkbox.jsx
+++ b/lib/checkbox.jsx
@@ -27,6 +27,7 @@ import { MDCFormField } from '@material/form-field';
 
 const NON_NATIVE_PROPS = [
   'label', 'className', 'indeterminate', 'supportsTouch', 'type', 'disablesMdcInstance',
+  'mdcCheckboxRef', 'mdcFormFieldRef',
 ];
 
 function NativeInput(props) {
@@ -47,6 +48,9 @@ function SimpleCheckbox(props) {
       return () => {};
     }
     const mdcComponent = new MDCCheckbox(rootElement.current);
+    if (props.mdcCheckboxRef) {
+      props.mdcCheckboxRef.current = mdcComponent; // eslint-disable-line no-param-reassign
+    }
     return () => {
       mdcComponent.destroy();
     };
@@ -87,12 +91,17 @@ function CheckboxWithLabel(props) {
   }
 
   const rootElement = useRef();
+  const mdcCheckboxRef = props.mdcCheckboxRef || (props.disablesMdcInstance ? null : useRef());
 
   useEffect(() => {
     if (props.disablesMdcInstance) {
       return () => {};
     }
     const mdcComponent = new MDCFormField(rootElement.current);
+    mdcComponent.input = mdcCheckboxRef.current;
+    if (props.mdcFormFieldRef) {
+      props.mdcFormFieldRef.current = mdcComponent; // eslint-disable-line no-param-reassign
+    }
     return () => {
       mdcComponent.destroy();
     };
@@ -109,7 +118,7 @@ function CheckboxWithLabel(props) {
 
   return (
     <div className={classNames.join(' ')} ref={rootElement}>
-      <SimpleCheckbox {...props}/>
+      <SimpleCheckbox mdcCheckboxRef={mdcCheckboxRef} {...props}/>
       <label {...labelProps}>{props.label}</label>
     </div>
   );
@@ -132,6 +141,10 @@ function CheckboxWithLabel(props) {
  * instantiate MDC Component. Default to `false`.
  * @param {boolean} [props.supportsTouch] Whether to support touch in Material Design
  * specification. Material Design spec advises that touch targets should be at least 48 x 48 px.
+ * @param {React.MutableRefObject} [props.mdcCheckboxRef] MutableRefObject which bind an
+ * MDCCheckbox instance to. The instance is not bind if `props.disablesMdcInstance` is `true`.
+ * @param {React.MutableRefObject} [props.mdcFormFieldRef] MutableRefObject which bind an
+ * MDCormField instance to. The instance is not bind if `props.disablesMdcInstance` is `true`.
  * @returns {DetailedReactHTMLElement}
  * @exports material-react-js
  */

--- a/lib/data-table.jsx
+++ b/lib/data-table.jsx
@@ -173,6 +173,9 @@ function Cell(props) {
  * @param {boolean} [props.usesStickyHeader] Specify `true` if you want to make header
  * row sticky (fixed) on vertical scroll, otherwise `false`. Default to `false`. (Note:
  * Sticky header feature is not compatible with IE11 browsers.)
+ * @param {React.MutableRefObject} [props.mdcDataTableRef] MutableRefObject which bind an
+ * MDCDataTable instance to. The instance is bind only if `props.usesRowSelection` is
+ * `true` or `props.columns` includes some sortable columns.
  * @param {EventHandler} [props.onScroll] Specifies event handler that is called when
  * table is scrolled.
  * @param {EventHandler} [props.onRowSelectionChanged] Specifies event handler that is
@@ -189,7 +192,7 @@ function Cell(props) {
 export default function DataTable(props) {
   const sortable = props.columns.some((column) => column.isSortable);
   const rootElement = sortable || props.usesRowSelection ? useRef() : null;
-  const mdcComponentRef = sortable || props.usesRowSelection ? useRef() : null;
+  const mdcComponentRef = props.mdcDataTableRef || (rootElement ? useRef() : null);
 
   useEffect(() => {
     if (sortable || props.usesRowSelection) {

--- a/lib/dialog.jsx
+++ b/lib/dialog.jsx
@@ -45,6 +45,8 @@ const EVENTS = [
  * @param {string} props.buttons[].label The label of the action button.
  * @param {string} [props.buttons[].isDefault] Specifies `true` if the button means the
  * default action, otherwise `false`. Default to `false`.
+ * @param {React.MutableRefObject} [props.mdcDialogRef] MutableRefObject which bind an
+ * MDCDialog instance to.
  * @param {EventHandler} [props.onOpening] Specifies event handler that is called when
  * the dialog begins its opening animation.
  * @param {EventHandler} [props.onOpened] Specifies event handler that is called when
@@ -100,7 +102,7 @@ const EVENTS = [
  */
 export default function Dialog(props) {
   const rootElement = useRef();
-  const mdcComponent = useRef();
+  const mdcComponent = props.mdcDialogRef || useRef();
 
   useEffect(() => {
     mdcComponent.current = new MDCDialog(rootElement.current);

--- a/lib/icon-button.jsx
+++ b/lib/icon-button.jsx
@@ -25,7 +25,7 @@ import React, { useEffect, useRef } from 'react';
 import { MDCRipple } from '@material/ripple';
 
 const NON_NATIVE_PROPS = [
-  'className', 'icon', 'ref', 'disablesMdcInstance',
+  'className', 'icon', 'ref', 'disablesMdcInstance', 'mdcRippleRef',
 ];
 
 const generateRootClassName = (props) => {
@@ -46,6 +46,8 @@ const generateRootClassName = (props) => {
  * @param {string} [props.icon] The inner text of the icon element if adding the icon.
  * @param {boolean} [props.disablesMdcInstance] Specifies `true` if you do not want to
  * instantiate MDCRipple Component. Default to `false`.
+ * @param {React.MutableRefObject} [props.mdcRippleRef] MutableRefObject which bind an
+ * MDCRipple instance to. The instance is not bind if `props.disablesMdcInstance` is `true`.
  * @returns {DetailedReactHTMLElement}
  * @example
  * import { IconButton } from 'material-react-js';
@@ -79,6 +81,9 @@ export default function IconButton(props) {
     }
     const mdcComponent = new MDCRipple(rootElement.current);
     mdcComponent.unbounded = true;
+    if (props.mdcRippleRef) {
+      props.mdcRippleRef.current = mdcComponent; // eslint-disable-line no-param-reassign
+    }
     return () => {
       mdcComponent.destroy();
     };

--- a/lib/icon-toggle.jsx
+++ b/lib/icon-toggle.jsx
@@ -28,7 +28,7 @@ import { MDCRipple } from '@material/ripple';
 const NON_NATIVE_PROPS = [
   'className', 'iconClassName', 'onIcon', 'offIcon', 'isOnState', 'label',
   'aria-label', 'aria-pressed', 'data-aria-label-off', 'data-aria-label-on',
-  'ref', 'disablesMdcInstance',
+  'ref', 'disablesMdcInstance', 'mdcIconButtonToggleRef', 'mdcRippleRef',
 ];
 
 const generateIconClassName = (props, isOnIcon) => {
@@ -84,6 +84,10 @@ const generateRootClassName = (props) => {
  * @param {boolean} [props.disablesMdcInstance] Specifies `true` if you do not want to
  * instantiate MDCRipple Component. `MDCIconButtonToggle` is instantiated regardless
  * of the setting of this property. Default to `false`.
+ * @param {React.MutableRefObject} [props.mdcIconButtonToggleRef] MutableRefObject which
+ * bind an MDCIconButtonToggle instance to.
+ * @param {React.MutableRefObject} [props.mdcRippleRef] MutableRefObject which bind an
+ * MDCRipple instance to. The instance is not bind if `props.disablesMdcInstance` is `true`.
  * @returns {DetailedReactHTMLElement}
  * @example
  * import { IconToggle } from 'material-react-js';
@@ -128,7 +132,7 @@ const generateRootClassName = (props) => {
  */
 function IconToggle(props) {
   const rootElement = useRef();
-  const mdcComponentRef = useRef();
+  const mdcComponentRef = props.mdcIconButtonToggleRef || useRef();
 
   useEffect(() => {
     mdcComponentRef.current = new MDCIconButtonToggle(rootElement.current);
@@ -142,6 +146,9 @@ function IconToggle(props) {
       return () => {};
     }
     const mdcComponent = new MDCRipple(rootElement.current);
+    if (props.mdcRippleRef) {
+      props.mdcRippleRef.current = mdcComponent; // eslint-disable-line no-param-reassign
+    }
     return () => {
       mdcComponent.destroy();
     };

--- a/lib/radio.jsx
+++ b/lib/radio.jsx
@@ -27,6 +27,7 @@ import { MDCFormField } from '@material/form-field';
 
 const NON_NATIVE_PROPS = [
   'label', 'className', 'indeterminate', 'supportsTouch', 'type', 'disablesMdcInstance',
+  'mdcRadioRef', 'mdcFormFieldRef',
 ];
 
 function NativeInput(props) {
@@ -44,6 +45,9 @@ function SimpleRadio(props) {
       return () => {};
     }
     const mdcComponent = new MDCRadio(rootElement.current);
+    if (props.mdcRadioRef) {
+      props.mdcRadioRef.current = mdcComponent; // eslint-disable-line no-param-reassign
+    }
     return () => {
       mdcComponent.destroy();
     };
@@ -77,12 +81,17 @@ function RadioWithLabel(props) {
   }
 
   const rootElement = useRef();
+  const mdcRadioRef = props.mdcRadioRef || (props.disablesMdcInstance ? null : useRef());
 
   useEffect(() => {
     if (props.disablesMdcInstance) {
       return () => {};
     }
     const mdcComponent = new MDCFormField(rootElement.current);
+    mdcComponent.input = mdcRadioRef.current;
+    if (props.mdcFormFieldRef) {
+      props.mdcFormFieldRef.current = mdcComponent; // eslint-disable-line no-param-reassign
+    }
     return () => {
       mdcComponent.destroy();
     };
@@ -99,7 +108,7 @@ function RadioWithLabel(props) {
 
   return (
     <div className={classNames.join(' ')} ref={rootElement}>
-      <SimpleRadio {...props}/>
+      <SimpleRadio mdcRadioRef={mdcRadioRef} {...props}/>
       <label {...labelProps}>{props.label}</label>
     </div>
   );
@@ -120,6 +129,10 @@ function RadioWithLabel(props) {
  * instantiate MDC Component. Default to `false`.
  * @param {boolean} [props.supportsTouch] Whether to support touch in Material Design
  * specification. Material Design spec advises that touch targets should be at least 48 x 48 px.
+ * @param {React.MutableRefObject} [props.mdcRadioRef] MutableRefObject which bind an
+ * MDCRadio instance to. The instance is not bind if `props.disablesMdcInstance` is `true`.
+ * @param {React.MutableRefObject} [props.mdcFormFieldRef] MutableRefObject which bind an
+ * MDCormField instance to. The instance is not bind if `props.disablesMdcInstance` is `true`.
  * @returns {DetailedReactHTMLElement}
  * @exports material-react-js
  */

--- a/lib/select.jsx
+++ b/lib/select.jsx
@@ -75,6 +75,8 @@ const getItemValue = (item, itemsValueAttr, index) => {
  * Default to `false`.
  * @param {boolean} [props.disabled] Specifies `true` if you want to disable the select.
  * Default to `false`.
+ * @param {React.MutableRefObject} [props.mdcSelectRef] MutableRefObject which bind an
+ * MDCSelect instance to.
  * @param {EventHandler} [props.onChange] Specifies event handler that is called when
  * a option has been selected.
  * @returns {DetailedReactHTMLElement}
@@ -82,7 +84,7 @@ const getItemValue = (item, itemsValueAttr, index) => {
  */
 export default function Select(props) {
   const rootElement = useRef();
-  const mdcComponentRef = useRef();
+  const mdcComponentRef = props.mdcSelectRef || useRef();
 
   useEffect(() => {
     mdcComponentRef.current = new MDCSelect(rootElement.current);

--- a/lib/snackbar.jsx
+++ b/lib/snackbar.jsx
@@ -58,6 +58,8 @@ const generateRootClassName = (props) => {
  * @param {string} [props.isLeading] Specifies `true` if the snackbar is displayed on the
  * leading egdge of the screen (the left side in LTR, or the right side in RTL). Specifying
  * `false`(default), the snackbar are centered horizontally within the viewport.
+ * @param {React.MutableRefObject} [props.mdcSnackbarRef] MutableRefObject which bind an
+ * MDCSnackbar instance to.
  * @param {EventHandler} [props.onOpening] Specifies event handler that is called when
  * the snackbar begins its opening animation.
  * @param {EventHandler} [props.onOpened] Specifies event handler that is called when
@@ -73,7 +75,7 @@ const generateRootClassName = (props) => {
  */
 export default function Snackbar(props) {
   const rootElement = useRef();
-  const mdcComponent = useRef();
+  const mdcComponent = props.mdcSnackbarRef || useRef();
 
   useEffect(() => {
     mdcComponent.current = new MDCSnackbar(rootElement.current);

--- a/lib/tab-bar.jsx
+++ b/lib/tab-bar.jsx
@@ -30,6 +30,8 @@ import { MDCTabBar } from '@material/tab-bar';
  * @function TabBar
  * @param {Object} props
  * @param {string} [props.className] The class name that is added to the root element.
+ * @param {React.MutableRefObject} [props.mdcTabBarRef] MutableRefObject which bind an
+ * MDCTabBar instance to.
  * @param {EventHandler} [props.onActivated] An event handler of React that is associated with
  * `button` element.
  * @returns {DetailedReactHTMLElement}
@@ -37,7 +39,7 @@ import { MDCTabBar } from '@material/tab-bar';
  */
 export default function TabBar(props) {
   const rootElement = useRef();
-  const mdcComponent = useRef();
+  const mdcComponent = props.mdcTabBarRef || useRef();
 
   useEffect(() => {
     mdcComponent.current = new MDCTabBar(rootElement.current);

--- a/lib/tab.jsx
+++ b/lib/tab.jsx
@@ -25,7 +25,7 @@ import React, { useRef, useEffect } from 'react';
 import { MDCTab } from '@material/tab';
 
 const NON_NATIVE_PROPS = [
-  'label', 'className', 'active', 'icon', 'iconClassName', 'ref',
+  'label', 'className', 'active', 'icon', 'iconClassName', 'ref', 'mdcTabRef',
 ];
 
 const generateRootClassName = (props) => {
@@ -63,6 +63,8 @@ function IconElement(props) {
  * @param {string} [props.iconClassName] The class name that is added to the icon element if
  * adding the icon. The component renders an icon on the tab if either this attribute or
  * `props.icon` is present.
+ * @param {React.MutableRefObject} [props.mdcTabRef] MutableRefObject which bind an
+ * MDCTab instance to.
  * @returns {DetailedReactHTMLElement}
  * @exports material-react-js
  */
@@ -71,6 +73,9 @@ export default function Tab(props) {
 
   useEffect(() => {
     const mdcComponent = new MDCTab(rootElement.current);
+    if (props.mdcTabRef) {
+      props.mdcTabRef.current = mdcComponent; // eslint-disable-line no-param-reassign
+    }
     return () => {
       mdcComponent.destroy();
     };

--- a/lib/textfield.jsx
+++ b/lib/textfield.jsx
@@ -27,6 +27,7 @@ import { MDCTextField } from '@material/textfield';
 const NON_NATIVE_PROPS = [
   'id', 'value', 'defaultValue', 'type', 'variation', 'label', 'className', 'helperText',
   'showsHelperPersistently', 'showsHelperAsValidation', 'rows', 'cols', 'resizable',
+  'mdcTextFieldRef',
 ];
 
 const generateRootClassName = (props) => {
@@ -149,12 +150,14 @@ function HelperText(props) {
  * @param {boolean} [props.resizable] Specifies `true` allowing the user to resize the textarea.
  * If `props.variation` is not `'textarea'` or `'filled-textarea'`, this attribute is ignored.
  * Default to `false`
+ * @param {React.MutableRefObject} [props.mdcTextFieldRef] MutableRefObject which bind an
+ * MDCTextField instance to.
  * @returns {DetailedReactHTMLElement}
  * @exports material-react-js
  */
 export default function TextField(props) {
   const rootElement = useRef();
-  const mdcComponentRef = useRef();
+  const mdcComponentRef = props.mdcTextFieldRef || useRef();
 
   useEffect(() => {
     const hasFocus = document.hasFocus() && document.activeElement === rootElement.current;


### PR DESCRIPTION
I changed to be able to get an instance of MDC.
An instance of MDC can be got setting `React.MutableRefObject` in `mdcXxxRef` property